### PR TITLE
A11yYOW abbreviation in image alt is redundant, cryptic, confusing and embarrassing

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>

--- a/faq.html
+++ b/faq.html
@@ -14,7 +14,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>

--- a/presos.html
+++ b/presos.html
@@ -14,7 +14,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>

--- a/register.html
+++ b/register.html
@@ -13,7 +13,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>

--- a/schedule.html
+++ b/schedule.html
@@ -14,7 +14,7 @@
     <header role="banner">
         <div>
             <nav role="navigation" id="menu">
-                <img src="images/logo.png" alt="A11yYOW Accessibility Camp Ottawa">
+                <img src="images/logo.png" alt="Accessibility Camp Ottawa">
                 <a href="index.html">Home</a>
                 <a href="register.html">Register</a>
                 <a href="presos.html">Presentations</a>


### PR DESCRIPTION
Snipped so that screen readers will say “Accessibility Camp Ottawa” instead of “A 1 1 Y Y O W Accessibility Camp Ottawa” every time a page is loaded.
