### PR TITLE
Fix paragraph tag in Robert's bio

### DIFF
--- a/presos-fr.html
+++ b/presos-fr.html
@@ -31,7 +31,7 @@ présentations</a>.</p>
                 telles que les vidéos descriptifs, le sous-titrage, l'interprétation gestuelle et le respect de l'accessibilité web - a11y - gagne en proéminence dans leur importance et disponibilité. </p>
             <p>Accessible Media Inc. (AMI) y répond avec un nombre d'initiatives incluant la description des pratiques exemplaires adoptées par l'industrie, le guide télé en vidéo descriptif, un diffuseur de médias en ligne accessible - le AMI-player - et
                 le lancement d'un troisième service de diffusion AMI-télé. </p>
-            </p>Robert travaille dans l'industrie de l'accessibilité depuis 1999. Il est un prêcheur de l'industrie, bâtisseur de communauté, formateur et développeur avec de l'expérience au gouvernement fédéral canadien et à l'étranger. Robert a passé plusieurs
+            <p>Robert travaille dans l'industrie de l'accessibilité depuis 1999. Il est un prêcheur de l'industrie, bâtisseur de communauté, formateur et développeur avec de l'expérience au gouvernement fédéral canadien et à l'étranger. Robert a passé plusieurs
             années comme gestionnaire de l'accessibilité pour une grande institution financière canadienne. Il est membre du comité de développement des normes d'information et de communications AODA et est présentement président du comité des pratiques
             exemplaires du vidéo descriptif du CRTC.</p>
             <div style="clear:left"></div>

--- a/presos.html
+++ b/presos.html
@@ -30,7 +30,7 @@ redirect_from:
                 captioning, signing as well as web accessibility compliance - a11y - are gaining prominence in their importance and availability. </p>
             <p>Accessible Media Inc. (AMI) is ‎responding to this through a number of initiatives including industry adopted description best practices, a described video TV Guide, an accessible online media player - the AMI-player - and the launch of a
                 third broadcast service AMI-télé. </p>
-            </p>Robert has worked in the accessibility industry since 1999. He is an industry advocate, community builder, trainer and developer with experience from the Canadian federal government and abroad. Robert spent many years as the manager of accessibility
+            <p>Robert has worked in the accessibility industry since 1999. He is an industry advocate, community builder, trainer and developer with experience from the Canadian federal government and abroad. Robert spent many years as the manager of accessibility
             for a major Canadian financial institution. He sat as a member of the AODA Information and Communications Standards Development Committee and is currently Chair of the CRTC Described Video Best Practices Committee.</p>
         </div>
     </div>
@@ -65,7 +65,7 @@ redirect_from:
 We'll start by turning on VoiceOver, and adjusting some settings. Then we will practice some simple gestures. With this foundation in place, we'll go through (and also practice) a set of VoiceOver test procedures for native apps and mobile web content. Finally we'll look at wireless keyboard testing techniques and procedures.</p>
 <p>Bring your iPhone or iPad ,and headphones/earbuds if possible!</p>
             <p>Aidan Tierney is a Senior Accessibility Consultant at IBM Canada. He works with large enterprises to help them meet accessibility standards. This work includes advising customers on accessibility strategy, conducting assessments, delivering training to testers and developers and remediating code. Aidan has presented at The Guelph Accessibility Conference, Accessibility Camp Toronto and CSUN.</p>
-  
+
 	</div>
 	<div class="col-md-6">
 		           <h2 id="derek">Keynote <br />By Derek Featherstone </h2>
@@ -83,11 +83,11 @@ We'll start by turning on VoiceOver, and adjusting some settings. Then we will p
 	<dd><p>I will present 10 tests that can be performed quickly to measure the accessibility of a web page. If you are a developer, you can fix before posting live. If you are a project
         manager or a client, you can ensure the level of accessibility without advanced coding knowledge.</p> </dd>
 	<dt>Is It WCAG 2.0 Compliant? by Rabab Gomaa</dt>
-<dd><p>Learn how to assess a web page against the Web Content Accessibility Guidelines (WCAG) 2.0 checkpoints. At the end of the session, you will able to measure the accessibility compliance of a web page, use web accessibility tools effectively and run screen reader tests.<br>  
-If you are reporting on the web accessibility of your website, or you want to know how to evaluate the accessibility of your work, this session is for you.</p> 
+<dd><p>Learn how to assess a web page against the Web Content Accessibility Guidelines (WCAG) 2.0 checkpoints. At the end of the session, you will able to measure the accessibility compliance of a web page, use web accessibility tools effectively and run screen reader tests.<br>
+If you are reporting on the web accessibility of your website, or you want to know how to evaluate the accessibility of your work, this session is for you.</p>
 <p>Rabab Gomaa is a web developer with over 15 years of experience. Her primary focus has been web accessibility following refinement study at the university of Montreal in 2009.
 Currently, Rabab works at increasing the awareness of web accessibility in organizations & communities and studying for a Master of Information Studies (Information Management) at University of Ottawa.</p> </dd>
 </dl>
-	
-		
+
+
 </ul>


### PR DESCRIPTION
Tag was closing instead of opening the block.
Some whitespace cleaning was included because of the EditorConfig settings.
